### PR TITLE
Use ItemInovked rather than ItemClicked for ArticlesListView

### DIFF
--- a/RssReader/Views/FeedView.xaml
+++ b/RssReader/Views/FeedView.xaml
@@ -297,7 +297,7 @@
                                       AllowDrop="True"
                                       IsSwipeEnabled="True"
                                       IsItemClickEnabled="True"
-                                      ItemClick="ArticlesListView_ItemClick"
+                                      ItemInvoked="ArticlesListView_ItemInvoked"
                                       ItemContainerStyle="{StaticResource FeedView}"
                                       ItemTemplate="{StaticResource ArticleItemViewTemplate}"
                                       Visibility="{x:Bind ViewModel.CurrentFeed.IsEmpty, Mode=OneWay, ConverterParameter=Reverse, Converter={StaticResource BooleanToVisibilityConverter}}" />

--- a/RssReader/Views/FeedView.xaml.cs
+++ b/RssReader/Views/FeedView.xaml.cs
@@ -69,8 +69,8 @@ namespace RssReader.Views
         /// way to prevent this is to use a one-way binding, and update CurrentArticle
         /// in this ItemClick event handler. 
         /// </remarks>
-        private void ArticlesListView_ItemClick(object sender, ItemClickEventArgs e) => 
-            ViewModel.CurrentArticle = e.ClickedItem as ArticleViewModel;
+        private void ArticlesListView_ItemInvoked(object sender, ListViewItem listViewItem) =>
+            ViewModel.CurrentArticle = ArticlesListView.ItemFromContainer(listViewItem) as ArticleViewModel;
 
         /// <summary>
         /// Updates the favorites list when the user stars or unstars an article. 


### PR DESCRIPTION
This fixes an issue which prevented keyboard navigation of the
ArticlesListview from updaing the webview with the current article.